### PR TITLE
Fixes for rust-stable, mavlink2, and support for tcp in/out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,12 @@ version = "0.4"
 optional = true
 
 [dependencies.byteorder]
-version = "1.3"
+version = "0.5.3"
 optional = true
 
 [features]
 "emit-description" = []
 "std" = ["byteorder"]
 "mavlink2" = []
+"udp" = []
 default= ["std", "mavlink2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ optional = true
 "mavlink2" = []
 "udp" = []
 "tcp" = []
-default= ["std", "mavlink2",  "tcp"]
+default= ["std", "mavlink2", "tcp", "udp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
+
 [package]
 name = "mavlink"
 version = "0.4.2"
-authors = ["Tim Ryan"]
+authors = ["Todd Stellanova", "Michal Podhradsky", "Kevin Mehall", "Tim Ryan"]
 build = "build/main.rs"
-edition = "2018"
-description = "Parses the MAVLink data interchange format for UAVs."
+description = "Implements the MAVLink data interchange format for UAVs."
 license = "MIT/Apache-2.0"
-repository = "https://github.com/3drobotics/rust-mavlink"
+repository = "https://github.com/tstellanova/rust-mavlink.git"
 
 [build-dependencies]
 crc16 = "0.3.3"
@@ -31,11 +31,11 @@ version = "0.4"
 optional = true
 
 [dependencies.byteorder]
-version = "0.5.3"
+version = "1.3"
 optional = true
 
 [features]
 "emit-description" = []
-"std" = ["byteorder","serial"]
+"std" = ["byteorder"]
 "mavlink2" = []
-default= ["std"]
+default= ["std", "mavlink2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,5 @@ optional = true
 "std" = ["byteorder"]
 "mavlink2" = []
 "udp" = []
-default= ["std", "mavlink2"]
+"tcp" = []
+default= ["std", "mavlink2",  "tcp"]

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -320,11 +320,13 @@ impl MavMessage {
         quote!(#name)
     }
 
-    fn emit_name_types(&self) -> Vec<Tokens> {
-        self.fields
+    fn emit_name_types(&self) -> (Vec<Tokens>, usize) {
+        let mut encoded_payload_len: usize = 0;
+        let field_toks = self.fields
             .iter()
             .map(|field| {
                 let nametype = field.emit_name_type();
+                encoded_payload_len +=  field.mavtype.len();
 
                 #[cfg(feature = "emit-description")]
                 let description = self.emit_description();
@@ -337,7 +339,8 @@ impl MavMessage {
                     #nametype
                 }
             })
-            .collect::<Vec<Tokens>>()
+            .collect::<Vec<Tokens>>();
+        (field_toks, encoded_payload_len)
     }
 
     /// Generate description for the given message
@@ -368,6 +371,9 @@ impl MavMessage {
             .map(|f| {
                 f.rust_reader()
             }).collect::<Vec<Tokens>>();
+
+            let encoded_len_name = Ident::from(format!("{}_DATA::ENCODED_LEN", self.name));
+
             if deser_vars.is_empty() {
                 // struct has no fields
                 quote!{
@@ -375,7 +381,19 @@ impl MavMessage {
                 }
             } else {
                 quote!{
+                    let avail_len = _input.len();
+
+                    //fast zero copy
                     let mut buf = Bytes::from(_input).into_buf();
+
+                    // handle payload length truncuation due to empty fields
+                    if avail_len < #encoded_len_name {
+                        //copy available bytes into an oversized buffer filled with zeros
+                        let mut payload_buf  = [0; #encoded_len_name];
+                        payload_buf[0..avail_len].copy_from_slice(_input);
+                        buf = Bytes::from(&payload_buf[..]).into_buf();
+                    }
+
                     let mut _struct = Self::default();
                     #(#deser_vars)*
                     Some(_struct)
@@ -385,7 +403,9 @@ impl MavMessage {
 
     fn emit_rust(&self) -> Tokens {
         let msg_name = self.emit_struct_name();
-        let name_types = self.emit_name_types();
+        let (name_types, msg_encoded_len) = self.emit_name_types();
+        let payload_len_desc = Ident::from(format!("pub const ENCODED_LEN: usize = {};", msg_encoded_len) );
+
         let deser_vars = self.emit_deserialize_vars();
         let serialize_vars = self.emit_serialize_vars();
 
@@ -403,6 +423,8 @@ impl MavMessage {
             }
 
             impl #msg_name {
+                #payload_len_desc
+
                 pub fn deser(_input: &[u8]) -> Option<Self> {
                     #deser_vars
                 }
@@ -421,7 +443,7 @@ pub struct MavField {
     pub name: String,
     pub description: Option<String>,
     pub enumtype: Option<String>,
-    pub display: Option<String>
+    pub display: Option<String>,
 }
 
 impl MavField {
@@ -461,6 +483,7 @@ impl MavField {
         let fieldtype = self.emit_type(); 
         quote!(pub #name: #fieldtype,)
     }
+
 
     /// Emit writer
     fn rust_writer(&self) -> Tokens {

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -509,7 +509,7 @@ impl MavField {
                 let val = Ident::from("from_".to_string() + &self.mavtype.rust_type());
                 quote!(
                     #tmp
-                    #name = FromPrimitive::#val(tmp).expect("Unexpected enum value.");
+                    #name = FromPrimitive::#val(tmp).expect(&format!("Unexpected enum value {}.",tmp));
                 )
             }
         } else {

--- a/common.xml
+++ b/common.xml
@@ -3888,7 +3888,7 @@
       <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="float[16]" name="controls">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
-      <field type="uint8_t" name="mode" >System mode. Includes arming state.</field>
+      <field type="uint8_t" name="mode" enum="MAV_MODE_FLAG"  display="bitmask">System mode. Includes arming state.</field>
       <field type="uint64_t" name="flags" display="bitmask">Flags as bitfield, reserved for future use.</field>
     </message>
     <message id="100" name="OPTICAL_FLOW">

--- a/common.xml
+++ b/common.xml
@@ -3888,7 +3888,7 @@
       <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="float[16]" name="controls">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
-      <field type="uint8_t" name="mode" enum="MAV_MODE">System mode. Includes arming state.</field>
+      <field type="uint8_t" name="mode" >System mode. Includes arming state.</field>
       <field type="uint64_t" name="flags" display="bitmask">Flags as bitfield, reserved for future use.</field>
     </message>
     <message id="100" name="OPTICAL_FLOW">

--- a/src/bin/mavlink-dump.rs
+++ b/src/bin/mavlink-dump.rs
@@ -15,7 +15,7 @@ fn main() {
     let args: Vec<_> = env::args().collect();
 
     if args.len() < 2 {
-        println!("Usage: mavlink-dump (tcp|udpin|udpout|serial):(ip|dev):(port|baud)");
+        println!("Usage: mavlink-dump (tcpout|udpin|udpout|serial):(ip|dev):(port|baud)");
         return;
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -271,7 +271,7 @@ impl MavConnection for Tcp {
             let mut lock = self.reader.lock().expect("tcp read failure");
             match read_msg(&mut *lock) {
                 Ok( (header, msg) ) => {
-                    println!("recvd {:?}", header);
+//                    println!("recvd {:?}", header);
                     return Ok((header, msg) );
                 },
                 Err(e) => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -18,6 +18,11 @@ use std::net::{TcpListener, TcpStream};
 #[cfg(feature = "tcp")]
 use std::time::Duration;
 
+#[cfg(feature = "serial")]
+extern crate serial;
+#[cfg(feature = "serial")]
+use connection::serial::*;
+
 
 #[cfg(any(feature = "udp", feature = "tcp" )) ]
 use std::net::{ToSocketAddrs};
@@ -363,25 +368,25 @@ impl MavConnection for Tcp {
 
 #[cfg(feature = "serial" )]
 pub struct Serial {
-    port: Mutex<::serial::SystemPort>,
+    port: Mutex<serial::SystemPort>,
     sequence: Mutex<u8>,
 }
 
 #[cfg(feature = "serial" )]
 impl Serial {
     pub fn open(settings: &str) -> io::Result<Serial> {
-        let settings: Vec<&str> = settings.split(":").collect();
-        let port = settings[0];
-        let baud = settings[1].parse::<usize>().unwrap();
-        let mut port = ::serial::open(port)?;
+        let settings_toks: Vec<&str> = settings.split(":").collect();
+        let port = settings_toks[0];
+        let baud = settings_toks[1].parse::<usize>().unwrap();
+        let mut port = serial::open(port)?;
 
-        let baud = ::serial::core::BaudRate::from_speed(baud);
-        let settings = ::serial::core::PortSettings {
+        let baud = serial::core::BaudRate::from_speed(baud);
+        let settings = serial::core::PortSettings {
             baud_rate: baud,
-            char_size: ::serial::Bits8,
-            parity: ::serial::ParityNone,
-            stop_bits: ::serial::Stop1,
-            flow_control: ::serial::FlowNone,
+            char_size: serial::Bits8,
+            parity: serial::ParityNone,
+            stop_bits: serial::Stop1,
+            flow_control: serial::FlowNone,
         };
 
         port.configure(&settings)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 extern crate alloc;
 
 
-
 #[cfg(feature = "std")]
 use std::io::{Read, Result, Write};
 
@@ -20,11 +19,14 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(feature = "std")]
 mod connection;
 #[cfg(feature = "std")]
-pub use self::connection::{connect, MavConnection, Tcp};
+pub use self::connection::{connect, MavConnection};
 #[cfg(feature = "serial")]
 pub use self::connection::{Serial};
 #[cfg(feature = "udp")]
 pub use self::connection::{Udp};
+#[cfg(feature = "tcp")]
+pub use self::connection::{Tcp};
+
 
 extern crate bytes;
 use bytes::{Buf, Bytes, IntoBuf};
@@ -60,11 +62,11 @@ pub struct MavHeader {
 }
 
 
-#[allow(dead_code)]
-const MAV_STX: u8 = 0xFE;
+/// Message framing marker for mavlink v1
+pub const MAV_STX: u8 = 0xFE;
 
-#[allow(dead_code)]
-const MAV_STX_V2: u8 = 0xFD;
+/// Message framing marker for mavlink v2
+pub const MAV_STX_V2: u8 = 0xFD;
 
 
 impl MavHeader {
@@ -345,240 +347,9 @@ pub fn write_msg<W: Write>(w: &mut W, header: MavHeader, data: &MavMessage) -> R
     Ok(())
 }
 
-#[cfg(test)]
-mod test_message {
-    use super::*;
-
-    #[cfg(all(feature = "std", not(feature="mavlink2")))]
-    pub const HEARTBEAT: &'static [u8] = &[
-        MAV_STX, 0x09, 0xef, 0x01, 0x01, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03,
-        0xf1, 0xd7,
-    ];
-
-    #[cfg(all(feature = "std", feature="mavlink2"))]
-    pub const HEARTBEAT_V2: &'static [u8] = &[
-        MAV_STX_V2,  //magic
-        0x09, //payload len
-        0, //incompat flags
-        0, //compat flags
-        0xef, //seq 239
-        0x01,  //sys ID
-        0x01, //comp ID
-        0x00, 0x00, 0x00, //msg ID
-        0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03, //payload
-        16, 240,//checksum
-    ];
-
-    /// A COMMAND_LONG message with a truncated payload (allowed for empty fields)
-    #[cfg(all(feature = "std", feature="mavlink2"))]
-    pub const COMMAND_LONG_TRUNCATED_V2: &'static [u8] = &[
-        MAV_STX_V2, 30, 0, 0, 0, 0, 50,  //header
-        76, 0, 0, //msg ID
-        //truncated payload:
-        0, 0, 230, 66, 0, 64, 156, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 1,
-        // crc:
-        188, 195];
-
-
-    pub const COMMON_MSG_HEADER: MavHeader = MavHeader {
-        sequence: 239,
-        system_id: 1,
-        component_id: 1,
-    };
-
-    fn get_heartbeat_msg() -> common::HEARTBEAT_DATA {
-        common::HEARTBEAT_DATA {
-            custom_mode: 5,
-            mavtype: common::MavType::MAV_TYPE_QUADROTOR,
-            autopilot: common::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
-            base_mode: common::MavModeFlag::MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
-                | common::MavModeFlag::MAV_MODE_FLAG_STABILIZE_ENABLED
-                | common::MavModeFlag::MAV_MODE_FLAG_GUIDED_ENABLED
-                | common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
-            system_status: common::MavState::MAV_STATE_STANDBY,
-            mavlink_version: 3,
-        }
-    }
-
-
-    fn get_cmd_nav_takeoff_msg() -> common::COMMAND_INT_DATA {
-        common::COMMAND_INT_DATA {
-            param1: 1.0,
-            param2: 2.0,
-            param3: 3.0,
-            param4: 4.0,
-            x: 555,
-            y: 666,
-            z: 777.0,
-            command: common::MavCmd::MAV_CMD_NAV_TAKEOFF,
-            target_system: 42,
-            target_component: 84,
-            frame: common::MavFrame::MAV_FRAME_GLOBAL,
-            current: 73,
-            autocontinue: 17
-        }
-    }
-
-    fn get_hil_actuator_controls_msg() -> common::HIL_ACTUATOR_CONTROLS_DATA {
-        common::HIL_ACTUATOR_CONTROLS_DATA {
-            time_usec: 1234567 as u64,
-            flags: 0 as u64,
-            controls: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
-                10.0, 11.0, 12.0, 13.0, 14.0, 15.0] ,
-            mode: common::MavModeFlag::MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
-                | common::MavModeFlag::MAV_MODE_FLAG_STABILIZE_ENABLED
-                | common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
-        }
-    }
 
 
 
-    #[test]
-    pub fn test_read_heartbeat() {
-        #[cfg(all(feature = "std", not(feature="mavlink2")))]
-        let mut r = HEARTBEAT;
-        #[cfg(all(feature = "std", feature="mavlink2"))]
-        let mut r =  HEARTBEAT_V2;
-
-        let (header, msg) = read_msg(&mut r).expect("Failed to parse message");
-
-        println!("{:?}, {:?}", header, msg);
-
-        assert_eq!(header, COMMON_MSG_HEADER);
-        let heartbeat_msg = get_heartbeat_msg();
-
-        if let common::MavMessage::HEARTBEAT(msg) = msg {
-            assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
-            assert_eq!(msg.mavtype, heartbeat_msg.mavtype);
-            assert_eq!(msg.autopilot, heartbeat_msg.autopilot);
-            assert_eq!(msg.base_mode, heartbeat_msg.base_mode);
-            assert_eq!(msg.system_status, heartbeat_msg.system_status);
-            assert_eq!(msg.mavlink_version, heartbeat_msg.mavlink_version);
-        } else {
-            panic!("Decoded wrong message type")
-        }
-    }
-
-    #[test]
-    pub fn test_write_heartbeat() {
-        let mut v = vec![];
-        let heartbeat_msg = get_heartbeat_msg();
-        write_msg(
-            &mut v,
-            COMMON_MSG_HEADER,
-            &common::MavMessage::HEARTBEAT(heartbeat_msg.clone()),
-        )
-        .expect("Failed to write message");
-
-        #[cfg(all(feature = "std", not(feature="mavlink2")))] {
-            assert_eq!(&v[..], HEARTBEAT);
-        }
-
-        #[cfg(all(feature = "std", feature="mavlink2"))] {
-            assert_eq!(&v[..], HEARTBEAT_V2);
-        }
-    }
-
-    #[test]
-    pub fn test_echo_heartbeat() {
-        let mut v = vec![];
-        let send_msg = get_heartbeat_msg();
-        write_msg(
-            &mut v,
-            COMMON_MSG_HEADER,
-            &common::MavMessage::HEARTBEAT(send_msg.clone()),
-        ).expect("Failed to write message");
-
-        let mut c = v.as_slice();
-        let (_header, recv_msg) = read_msg(&mut c).expect("Failed to read");
-        assert_eq!(recv_msg.message_id(), 0);
-    }
-
-    #[test]
-    pub fn test_echo_command_int() {
-        let mut v = vec![];
-        let send_msg = get_cmd_nav_takeoff_msg();
-
-        write_msg(
-            &mut v,
-            COMMON_MSG_HEADER,
-            &common::MavMessage::COMMAND_INT(send_msg.clone()),
-        ).expect("Failed to write message");
-
-        let mut c = v.as_slice();
-        let (_header, recv_msg) = read_msg(&mut c).expect("Failed to read");
-
-        if let common::MavMessage::COMMAND_INT(recv_msg) = recv_msg {
-            assert_eq!(recv_msg.command, common::MavCmd::MAV_CMD_NAV_TAKEOFF);
-        } else {
-            panic!("Decoded wrong message type")
-        }
-    }
 
 
-    #[test]
-    pub fn test_echo_hil_actuator_controls() {
-        let mut v = vec![];
-        let send_msg = get_hil_actuator_controls_msg();
 
-        write_msg(
-            &mut v,
-            COMMON_MSG_HEADER,
-            &common::MavMessage::HIL_ACTUATOR_CONTROLS(send_msg.clone()),
-        ).expect("Failed to write message");
-
-        let mut c = v.as_slice();
-        let (_header, recv_msg) = read_msg(&mut c).expect("Failed to read");
-        if let common::MavMessage::HIL_ACTUATOR_CONTROLS(recv_msg) = recv_msg {
-            assert_eq!(common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
-            recv_msg.mode & common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED);
-        } else {
-            panic!("Decoded wrong message type")
-        }
-    }
-
-
-    #[test]
-    #[cfg(all(feature = "std", feature="mavlink2"))]
-    pub fn test_read_truncated_command_long() {
-        let mut r =  COMMAND_LONG_TRUNCATED_V2;
-        let (_header, recv_msg) = read_msg(&mut r).expect("Failed to parse COMMAND_LONG_TRUNCATED_V2");
-
-        if let common::MavMessage::COMMAND_LONG(recv_msg) = recv_msg {
-            assert_eq!(recv_msg.command, common::MavCmd::MAV_CMD_SET_MESSAGE_INTERVAL);
-        } else {
-            panic!("Decoded wrong message type")
-        }
-    }
-
-
-// TODO include a tlog file in this repo for testing
-//    #[test]
-//    #[cfg(all(feature = "std", not(feature="mavlink2")))]
-//    pub fn test_log_file() {
-//        use std::fs::File;
-//
-//        let path = "test.tlog";
-//        let mut f = File::open(path).unwrap();
-//
-//        loop {
-//            match self::read_msg(&mut f) {
-//                Ok((_, msg)) => {
-//                    println!("{:#?}", msg);
-//                }
-//                Err(e) => {
-//                    println!("Error: {:?}", e);
-//                    match e.kind() {
-//                        std::io::ErrorKind::UnexpectedEof => {
-//                            break;
-//                        },
-//                        _ => {
-//                            panic!("Unexpected error");
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
-
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+
+
 #[cfg(feature = "std")]
 use std::io::{Read, Result, Write};
 
@@ -18,10 +20,11 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(feature = "std")]
 mod connection;
 #[cfg(feature = "std")]
-pub use self::connection::{connect, MavConnection, Tcp, Udp};
+pub use self::connection::{connect, MavConnection, Tcp};
 #[cfg(feature = "serial")]
 pub use self::connection::{Serial};
-
+#[cfg(feature = "udp")]
+pub use self::connection::{Udp};
 
 extern crate bytes;
 use bytes::{Buf, Bytes, IntoBuf};
@@ -62,6 +65,7 @@ const MAV_STX: u8 = 0xFE;
 
 #[allow(dead_code)]
 const MAV_STX_V2: u8 = 0xFD;
+
 
 impl MavHeader {
     /// Return a default GCS header, seq is replaced by the connector
@@ -170,7 +174,9 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
         crc_calc.update(&[len as u8, seq, sysid, compid, msgid]);
         crc_calc.update(payload);
         crc_calc.update(&[MavMessage::extra_crc(msgid)]);
-        if crc_calc.get() != crc {
+        let recvd_crc = crc_calc.get();
+        if recvd_crc != crc {
+            println!("msg id {} len {} , crc got {} expected {}", msgid, len, crc, recvd_crc );
             continue;
         }
 
@@ -190,41 +196,60 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
 #[cfg(feature="mavlink2")]
 const MAVLINK_IFLAG_SIGNED: u8 = 0x01;
 
+const  MAVLINK_CORE_HEADER_LEN: usize =  9; ///< Length of core header (of the comm. layer)
+///
 /// Read a MAVLink v2  message from a Read stream.
 #[cfg(all(feature = "std", feature="mavlink2"))]
 pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
- loop {
+    loop {
         if r.read_u8()? != MAV_STX_V2 {
             continue;
         }
-        println!("Got STX");
-        let len = r.read_u8()? as usize;
-        println!("Got len: {}", len);
+        let mut header_buf = [0; MAVLINK_CORE_HEADER_LEN];
+        let mut idx = 0;
+
+//        println!("Got STX2");
+        let payload_len = r.read_u8()? as usize;
+        header_buf[idx] = payload_len as u8; idx+=1;
+        println!("Got payload_len: {}", payload_len);
         let incompat_flags = r.read_u8()?;
-        println!("Got incompat flags: {}", incompat_flags);
-        let _compat_flags = r.read_u8()?;
-        println!("Got compat flags: {}", _compat_flags);
+        header_buf[idx] = incompat_flags as u8; idx+=1;
+//        println!("Got incompat flags: {}", incompat_flags);
+        let compat_flags = r.read_u8()?;
+        header_buf[idx] = compat_flags as u8; idx+=1;
+//        println!("Got compat flags: {}", compat_flags);
+
         let seq = r.read_u8()?;
+        header_buf[idx] = seq as u8; idx+=1;
         println!("Got seq: {}", seq);
+
         let sysid = r.read_u8()?;
+        header_buf[idx] = sysid as u8; idx+=1;
         println!("Got sysid: {}", sysid);
+
         let compid = r.read_u8()?;
+        header_buf[idx] = compid as u8; idx+=1;
         println!("Got compid: {}", compid);
 
         let mut msgid_buf = [0;4];
         msgid_buf[0] = r.read_u8()?;
         msgid_buf[1] = r.read_u8()?;
         msgid_buf[2] = r.read_u8()?;
-        println!("Got msgid buf: {:?}", msgid_buf);
+        header_buf[idx] =  msgid_buf[0]; idx+=1;
+        header_buf[idx] =  msgid_buf[1]; idx+=1;
+        header_buf[idx] =  msgid_buf[2]; idx+=1;
+        println!("Got msgid buf: {:?} header_len: {} ", msgid_buf,idx);
+        println!("read H: {:?}",header_buf );
 
         let msgid: u32 = unsafe { transmute(msgid_buf) };
-        println!("Got msgid: {}", msgid);
+//        println!("Got msgid: {}", msgid);
 
         let mut payload_buf = [0; 255];
-        let payload = &mut payload_buf[..len];
+        let payload = &mut payload_buf[..payload_len];
         r.read_exact(payload)?;
 
         let crc = r.read_u16::<LittleEndian>()?;
+//        println!("got crc: {}", crc);
 
         if (incompat_flags & 0x01) == MAVLINK_IFLAG_SIGNED {
             let mut sign = [0;13];
@@ -232,14 +257,42 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
         }
 
         let mut crc_calc = crc16::State::<crc16::MCRF4XX>::new();
-        crc_calc.update(&[len as u8, seq, sysid, compid, msgid_buf[0],msgid_buf[1],msgid_buf[2]]);
+        /*
+        msg->checksum = crc_calculate(&buf[1], header_len-1);
+        crc_accumulate_buffer(&msg->checksum, _MAV_PAYLOAD(msg), msg->len);
+        crc_accumulate(crc_extra, &msg->checksum);
+        mavlink_ck_a(msg) = (uint8_t)(msg->checksum & 0xFF);
+        mavlink_ck_b(msg) = (uint8_t)(msg->checksum >> 8);
+        */
+
+        crc_calc.update(&header_buf);
+//        let header_crc = crc_calc.get();
+        //        let value_buf = &[len as u8, seq, sysid, compid, msgid_buf[0],msgid_buf[1],msgid_buf[2]];
+//        crc_calc.update(value_buf);
         crc_calc.update(payload);
-        crc_calc.update(&[MavMessage::extra_crc(msgid)]);
-        if crc_calc.get() != crc {
+
+//        let base_crc = crc_calc.get();
+        let extra_crc = MavMessage::extra_crc(msgid);
+//        println!("read header_crc: {} base_crc: {} extra_crc: {}",
+//                 header_crc, base_crc, extra_crc);
+
+        crc_calc.update(&[extra_crc]);
+        let recvd_crc = crc_calc.get();
+        if recvd_crc != crc {
+            println!("msg id {} len {} , crc got {} expected {}", msgid, payload_len, crc, recvd_crc );
+            continue;
+        } else {
+            println!("crc match!");
+        }
+
+        println!("payload_len: {} payload avail: {}", payload_len, payload.len());
+        if (msgid == 76) {
+            println!("ignoring CMD_LONG");
             continue;
         }
 
         if let Some(msg) = MavMessage::parse(msgid, payload) {
+            println!("valid parse");
             return Ok((
                 MavHeader {
                     sequence: seq,
@@ -249,6 +302,9 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
                 msg,
             ));
         }
+        else {
+            println!("invalid parse");
+        }
     }
 }
 
@@ -257,20 +313,33 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
 pub fn write_msg<W: Write>(w: &mut W, header: MavHeader, data: &MavMessage) -> Result<()> {
     let msgid = data.message_id();
     let payload = data.ser();
+//    println!("write payload_len : {}", payload.len());
 
     let header = &[
         MAV_STX_V2,
         payload.len() as u8,
+        0, //incompat_flags
+        0, //compat_flags
         header.sequence,
         header.system_id,
         header.component_id,
-        msgid as u8,
+        (msgid & 0x0000FF) as u8,
+        ((msgid & 0x00FF00) >> 8) as u8 ,
+        ((msgid & 0xFF0000) >> 16) as u8,
     ];
+
+//    println!("write H: {:?}",header );
+
 
     let mut crc = crc16::State::<crc16::MCRF4XX>::new();
     crc.update(&header[1..]);
+//    let header_crc = crc.get();
     crc.update(&payload[..]);
-    crc.update(&[MavMessage::extra_crc(msgid)]);
+//    let base_crc = crc.get();
+    let extra_crc = MavMessage::extra_crc(msgid);
+//    println!("write header_crc: {} base_crc: {} extra_crc: {}",
+//             header_crc, base_crc, extra_crc);
+    crc.update(&[extra_crc]);
 
     w.write_all(header)?;
     w.write_all(&payload[..])?;
@@ -310,10 +379,42 @@ pub fn write_msg<W: Write>(w: &mut W, header: MavHeader, data: &MavMessage) -> R
 mod test_message {
     use super::*;
 
+    #[cfg(all(feature = "std", not(feature="mavlink2")))]
     pub const HEARTBEAT: &'static [u8] = &[
-        0xfe, 0x09, 0xef, 0x01, 0x01, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03,
+        MAV_STX, 0x09, 0xef, 0x01, 0x01, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03,
         0xf1, 0xd7,
     ];
+
+
+
+    //buf[0] = msg->magic;
+    //buf[1] = msg->len;
+    //buf[2] = msg->incompat_flags;
+    //buf[3] = msg->compat_flags;
+    //buf[4] = msg->seq;
+    //buf[5] = msg->sysid;
+    //buf[6] = msg->compid;
+    //buf[7] = msg->msgid & 0xFF;
+    //buf[8] = (msg->msgid >> 8) & 0xFF;
+    //buf[9] = (msg->msgid >> 16) & 0xFF;
+
+    #[cfg(all(feature = "std", feature="mavlink2"))]
+    pub const HEARTBEAT_V2: &'static [u8] = &[
+        MAV_STX_V2,  //magic
+        0x09, //payload len
+        0, //incompat flags
+        0, //compat flags
+        0xef, //seq 239
+        0x01,  //sys ID
+        0x01, //comp ID
+        0x00, 0x00, 0x00, //msg ID
+        0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03, //payload
+        16, 240,//checksum
+    ];
+
+
+
+
     pub const HEARTBEAT_HEADER: MavHeader = MavHeader {
         sequence: 239,
         system_id: 1,
@@ -335,9 +436,12 @@ mod test_message {
     }
 
     #[test]
-    #[cfg(all(feature = "std", not(feature="mavlink2")))]
     pub fn test_read() {
+        #[cfg(all(feature = "std", not(feature="mavlink2")))]
         let mut r = HEARTBEAT;
+        #[cfg(all(feature = "std", feature="mavlink2"))]
+        let mut r =  HEARTBEAT_V2;
+
         let (header, msg) = read_msg(&mut r).expect("Failed to parse message");
 
         println!("{:?}, {:?}", header, msg);
@@ -358,7 +462,6 @@ mod test_message {
     }
 
     #[test]
-    #[cfg(all(feature = "std", not(feature="mavlink2")))]
     pub fn test_write() {
         let mut v = vec![];
         let heartbeat_msg = get_heartbeat_msg();
@@ -369,35 +472,60 @@ mod test_message {
         )
         .expect("Failed to write message");
 
-        assert_eq!(&v[..], HEARTBEAT);
-    }
 
-    #[cfg(feature = "std")]
-    use std::fs::File;
+        #[cfg(all(feature = "std", not(feature="mavlink2")))] {
+            assert_eq!(&v[..], HEARTBEAT);
+        }
 
-    #[test]
-    #[cfg(all(feature = "std", not(feature="mavlink2")))]
-    pub fn test_log_file() {
-        let path = "test.tlog";
-        let mut f = File::open(path).unwrap();
 
-        loop {
-            match self::read(&mut f) {
-                Ok((_, msg)) => {
-                    println!("{:#?}", msg);
-                }
-                Err(e) => {
-                    println!("Error: {:?}", e);
-                    match e.kind() {
-                        std::io::ErrorKind::UnexpectedEof => {
-                            break;
-                        },
-                        _ => {
-                            panic!("Unexpected error");
-                        }
-                    }
-                }
-            }
+        #[cfg(all(feature = "std", feature="mavlink2"))] {
+            assert_eq!(&v[..], HEARTBEAT_V2);
         }
     }
+
+    #[test]
+    pub fn test_echo() {
+        let mut v = vec![];
+        let heartbeat_msg = get_heartbeat_msg();
+        write_msg(
+            &mut v,
+            HEARTBEAT_HEADER,
+            &common::MavMessage::HEARTBEAT(heartbeat_msg.clone()),
+        ).expect("Failed to write message");
+
+        let mut c = v.as_slice();
+        let (_header, msg) = read_msg(&mut c).expect("Failed to read");
+        assert_eq!(msg.message_id(), 0);
+    }
+
+
+
+//    #[test]
+//    #[cfg(all(feature = "std", not(feature="mavlink2")))]
+//    pub fn test_log_file() {
+//        use std::fs::File;
+//
+//        let path = "test.tlog";
+//        let mut f = File::open(path).unwrap();
+//
+//        loop {
+//            match self::read_msg(&mut f) {
+//                Ok((_, msg)) => {
+//                    println!("{:#?}", msg);
+//                }
+//                Err(e) => {
+//                    println!("Error: {:?}", e);
+//                    match e.kind() {
+//                        std::io::ErrorKind::UnexpectedEof => {
+//                            break;
+//                        },
+//                        _ => {
+//                            panic!("Unexpected error");
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
 //        println!("Got STX2");
         let payload_len = r.read_u8()? as usize;
         header_buf[idx] = payload_len as u8; idx+=1;
-        println!("Got payload_len: {}", payload_len);
+//        println!("Got payload_len: {}", payload_len);
         let incompat_flags = r.read_u8()?;
         header_buf[idx] = incompat_flags as u8; idx+=1;
 //        println!("Got incompat flags: {}", incompat_flags);
@@ -221,15 +221,15 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
 
         let seq = r.read_u8()?;
         header_buf[idx] = seq as u8; idx+=1;
-        println!("Got seq: {}", seq);
+//        println!("Got seq: {}", seq);
 
         let sysid = r.read_u8()?;
         header_buf[idx] = sysid as u8; idx+=1;
-        println!("Got sysid: {}", sysid);
+//        println!("Got sysid: {}", sysid);
 
         let compid = r.read_u8()?;
         header_buf[idx] = compid as u8; idx+=1;
-        println!("Got compid: {}", compid);
+//        println!("Got compid: {}", compid);
 
         let mut msgid_buf = [0;4];
         msgid_buf[0] = r.read_u8()?;
@@ -238,8 +238,8 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
         header_buf[idx] =  msgid_buf[0]; idx+=1;
         header_buf[idx] =  msgid_buf[1]; idx+=1;
         header_buf[idx] =  msgid_buf[2]; idx+=1;
-        println!("Got msgid buf: {:?} header_len: {} ", msgid_buf,idx);
-        println!("read H: {:?}",header_buf );
+//        println!("Got msgid buf: {:?} header_len: {} ", msgid_buf,idx);
+//        println!("read H: {:?} header_len: {} ",header_buf , idx );
 
         let msgid: u32 = unsafe { transmute(msgid_buf) };
 //        println!("Got msgid: {}", msgid);
@@ -257,13 +257,6 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
         }
 
         let mut crc_calc = crc16::State::<crc16::MCRF4XX>::new();
-        /*
-        msg->checksum = crc_calculate(&buf[1], header_len-1);
-        crc_accumulate_buffer(&msg->checksum, _MAV_PAYLOAD(msg), msg->len);
-        crc_accumulate(crc_extra, &msg->checksum);
-        mavlink_ck_a(msg) = (uint8_t)(msg->checksum & 0xFF);
-        mavlink_ck_b(msg) = (uint8_t)(msg->checksum >> 8);
-        */
 
         crc_calc.update(&header_buf);
 //        let header_crc = crc_calc.get();
@@ -279,20 +272,16 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
         crc_calc.update(&[extra_crc]);
         let recvd_crc = crc_calc.get();
         if recvd_crc != crc {
-            println!("msg id {} len {} , crc got {} expected {}", msgid, payload_len, crc, recvd_crc );
+            println!("msg id {} payload_len {} , crc got {} expected {}", msgid, payload_len, crc, recvd_crc );
             continue;
-        } else {
-            println!("crc match!");
         }
 
-        println!("payload_len: {} payload avail: {}", payload_len, payload.len());
         if (msgid == 76) {
             println!("ignoring CMD_LONG");
             continue;
         }
 
         if let Some(msg) = MavMessage::parse(msgid, payload) {
-            println!("valid parse");
             return Ok((
                 MavHeader {
                     sequence: seq,
@@ -303,7 +292,7 @@ pub fn read_msg<R: Read>(r: &mut R) -> Result<(MavHeader, MavMessage)> {
             ));
         }
         else {
-            println!("invalid parse");
+            println!("invalid MavMessage::parse");
         }
     }
 }

--- a/tests/encode_decode_tests.rs
+++ b/tests/encode_decode_tests.rs
@@ -1,0 +1,236 @@
+
+extern crate mavlink;
+
+#[cfg(test)]
+mod test_encode_decode {
+
+    #[cfg(all(feature = "std", not(feature = "mavlink2")))]
+    pub const HEARTBEAT: &'static [u8] = &[
+        mavlink::MAV_STX, 0x09, 0xef, 0x01, 0x01, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03,
+        0xf1, 0xd7,
+    ];
+
+    #[cfg(all(feature = "std", feature = "mavlink2"))]
+    pub const HEARTBEAT_V2: &'static [u8] = &[
+        mavlink::MAV_STX_V2, //magic
+        0x09, //payload len
+        0, //incompat flags
+        0, //compat flags
+        0xef, //seq 239
+        0x01, //sys ID
+        0x01, //comp ID
+        0x00, 0x00, 0x00, //msg ID
+        0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03, //payload
+        16, 240, //checksum
+    ];
+
+    pub const COMMON_MSG_HEADER: mavlink::MavHeader = mavlink::MavHeader {
+        sequence: 239,
+        system_id: 1,
+        component_id: 1,
+    };
+
+    fn get_heartbeat_msg() -> mavlink::common::HEARTBEAT_DATA {
+        mavlink::common::HEARTBEAT_DATA {
+            custom_mode: 5,
+            mavtype: mavlink::common::MavType::MAV_TYPE_QUADROTOR,
+            autopilot: mavlink::common::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+            base_mode: mavlink::common::MavModeFlag::MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
+                | mavlink::common::MavModeFlag::MAV_MODE_FLAG_STABILIZE_ENABLED
+                | mavlink::common::MavModeFlag::MAV_MODE_FLAG_GUIDED_ENABLED
+                | mavlink::common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            system_status: mavlink::common::MavState::MAV_STATE_STANDBY,
+            mavlink_version: 3,
+        }
+    }
+
+
+    fn get_cmd_nav_takeoff_msg() -> mavlink::common::COMMAND_INT_DATA {
+        mavlink::common::COMMAND_INT_DATA {
+            param1: 1.0,
+            param2: 2.0,
+            param3: 3.0,
+            param4: 4.0,
+            x: 555,
+            y: 666,
+            z: 777.0,
+            command: mavlink::common::MavCmd::MAV_CMD_NAV_TAKEOFF,
+            target_system: 42,
+            target_component: 84,
+            frame: mavlink::common::MavFrame::MAV_FRAME_GLOBAL,
+            current: 73,
+            autocontinue: 17
+        }
+    }
+
+    fn get_hil_actuator_controls_msg() -> mavlink::common::HIL_ACTUATOR_CONTROLS_DATA {
+        mavlink::common::HIL_ACTUATOR_CONTROLS_DATA {
+            time_usec: 1234567 as u64,
+            flags: 0 as u64,
+            controls: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+            mode: mavlink::common::MavModeFlag::MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
+                | mavlink::common::MavModeFlag::MAV_MODE_FLAG_STABILIZE_ENABLED
+                | mavlink::common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+        }
+    }
+
+
+    #[test]
+    pub fn test_read_heartbeat() {
+        #[cfg(all(feature = "std", not(feature = "mavlink2")))]
+        let mut r = HEARTBEAT;
+        #[cfg(all(feature = "std", feature = "mavlink2"))]
+        let mut r = HEARTBEAT_V2;
+
+        let (header, msg) = mavlink::read_msg(&mut r).expect("Failed to parse message");
+
+        println!("{:?}, {:?}", header, msg);
+
+        assert_eq!(header, COMMON_MSG_HEADER);
+        let heartbeat_msg = get_heartbeat_msg();
+
+        if let mavlink::common::MavMessage::HEARTBEAT(msg) = msg {
+            assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
+            assert_eq!(msg.mavtype, heartbeat_msg.mavtype);
+            assert_eq!(msg.autopilot, heartbeat_msg.autopilot);
+            assert_eq!(msg.base_mode, heartbeat_msg.base_mode);
+            assert_eq!(msg.system_status, heartbeat_msg.system_status);
+            assert_eq!(msg.mavlink_version, heartbeat_msg.mavlink_version);
+        } else {
+            panic!("Decoded wrong message type")
+        }
+    }
+
+    #[test]
+    pub fn test_write_heartbeat() {
+        let mut v = vec![];
+        let heartbeat_msg = get_heartbeat_msg();
+        mavlink::write_msg(
+            &mut v,
+            COMMON_MSG_HEADER,
+            &mavlink::common::MavMessage::HEARTBEAT(heartbeat_msg.clone()),
+        )
+            .expect("Failed to write message");
+
+        #[cfg(all(feature = "std", not(feature = "mavlink2")))] {
+            assert_eq!(&v[..], HEARTBEAT);
+        }
+
+        #[cfg(all(feature = "std", feature = "mavlink2"))] {
+            assert_eq!(&v[..], HEARTBEAT_V2);
+        }
+    }
+
+    #[test]
+    pub fn test_echo_heartbeat() {
+        let mut v = vec![];
+        let send_msg = get_heartbeat_msg();
+
+        mavlink::write_msg(
+            &mut v,
+            COMMON_MSG_HEADER,
+            &mavlink::common::MavMessage::HEARTBEAT(send_msg.clone()),
+        ).expect("Failed to write message");
+
+        let mut c = v.as_slice();
+        let (_header, recv_msg) = mavlink::read_msg(&mut c).expect("Failed to read");
+        assert_eq!(recv_msg.message_id(), 0);
+    }
+
+    #[test]
+    pub fn test_echo_command_int() {
+        let mut v = vec![];
+        let send_msg = get_cmd_nav_takeoff_msg();
+
+        mavlink::write_msg(
+            &mut v,
+            COMMON_MSG_HEADER,
+            &mavlink::common::MavMessage::COMMAND_INT(send_msg.clone()),
+        ).expect("Failed to write message");
+
+        let mut c = v.as_slice();
+        let (_header, recv_msg) = mavlink::read_msg(&mut c).expect("Failed to read");
+
+        if let mavlink::common::MavMessage::COMMAND_INT(recv_msg) = recv_msg {
+            assert_eq!(recv_msg.command, mavlink::common::MavCmd::MAV_CMD_NAV_TAKEOFF);
+        } else {
+            panic!("Decoded wrong message type")
+        }
+    }
+
+
+    #[test]
+    pub fn test_echo_hil_actuator_controls() {
+        let mut v = vec![];
+        let send_msg = get_hil_actuator_controls_msg();
+
+        mavlink::write_msg(
+            &mut v,
+            COMMON_MSG_HEADER,
+            &mavlink::common::MavMessage::HIL_ACTUATOR_CONTROLS(send_msg.clone()),
+        ).expect("Failed to write message");
+
+        let mut c = v.as_slice();
+        let (_header, recv_msg) = mavlink::read_msg(&mut c).expect("Failed to read");
+        if let mavlink::common::MavMessage::HIL_ACTUATOR_CONTROLS(recv_msg) = recv_msg {
+            assert_eq!(mavlink::common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            recv_msg.mode & mavlink::common::MavModeFlag::MAV_MODE_FLAG_CUSTOM_MODE_ENABLED);
+        } else {
+            panic!("Decoded wrong message type")
+        }
+    }
+
+
+    /// A COMMAND_LONG message with a truncated payload (allowed for empty fields)
+    #[cfg(all(feature = "std", feature = "mavlink2"))]
+    pub const COMMAND_LONG_TRUNCATED_V2: &'static [u8] = &[
+        mavlink::MAV_STX_V2, 30, 0, 0, 0, 0, 50, //header
+        76, 0, 0, //msg ID
+        //truncated payload:
+        0, 0, 230, 66, 0, 64, 156, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 1,
+        // crc:
+        188, 195];
+
+    #[test]
+    #[cfg(all(feature = "std", feature = "mavlink2"))]
+    pub fn test_read_truncated_command_long() {
+        let mut r = COMMAND_LONG_TRUNCATED_V2;
+        let (_header, recv_msg) = mavlink::read_msg(&mut r).expect("Failed to parse COMMAND_LONG_TRUNCATED_V2");
+
+        if let mavlink::common::MavMessage::COMMAND_LONG(recv_msg) = recv_msg {
+            assert_eq!(recv_msg.command, mavlink::common::MavCmd::MAV_CMD_SET_MESSAGE_INTERVAL);
+        } else {
+            panic!("Decoded wrong message type")
+        }
+    }
+
+    // TODO include a tlog file in this repo for testing
+    //    #[test]
+    //    #[cfg(all(feature = "std", not(feature="mavlink2")))]
+    //    pub fn test_log_file() {
+    //        use std::fs::File;
+    //
+    //        let path = "test.tlog";
+    //        let mut f = File::open(path).unwrap();
+    //
+    //        loop {
+    //            match self::mavlink::read_msg(&mut f) {
+    //                Ok((_, msg)) => {
+    //                    println!("{:#?}", msg);
+    //                }
+    //                Err(e) => {
+    //                    println!("Error: {:?}", e);
+    //                    match e.kind() {
+    //                        std::io::ErrorKind::UnexpectedEof => {
+    //                            break;
+    //                        },
+    //                        _ => {
+    //                            panic!("Unexpected error");
+    //                        }
+    //                    }
+    //                }
+    //            }
+    //        }
+    //    }
+}

--- a/tests/tcp_loopback_tests.rs
+++ b/tests/tcp_loopback_tests.rs
@@ -1,0 +1,58 @@
+extern crate mavlink;
+
+#[cfg(test)]
+#[cfg(all(feature = "std", feature = "tcp"))]
+mod test_tcp_connections {
+    use std::thread;
+
+    /// Create a heartbeat message
+    pub fn heartbeat_message() -> mavlink::common::MavMessage {
+        mavlink::common::MavMessage::HEARTBEAT(mavlink::common::HEARTBEAT_DATA {
+            custom_mode: 0,
+            mavtype: mavlink::common::MavType::MAV_TYPE_QUADROTOR,
+            autopilot: mavlink::common::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+            base_mode: mavlink::common::MavModeFlag::empty(),
+            system_status: mavlink::common::MavState::MAV_STATE_STANDBY,
+            mavlink_version: 0x3,
+        })
+    }
+
+    /// Test whether we can send a message via TCP and receive it OK
+    #[test]
+    pub fn test_tcp_loopback() {
+        const RECEIVE_CHECK_COUNT: i32 = 3;
+
+        let server_thread = thread::spawn( {
+            move || {
+                //TODO consider using get_available_port to use a random port
+                let server = mavlink::connect("tcpin:0.0.0.0:14550")
+                    .expect("Couldn't create server");
+
+                let mut recv_count = 0;
+                for _i in 0..RECEIVE_CHECK_COUNT {
+                    if let Ok(_msg) = server.recv() {
+                        recv_count += 1;
+                    } else {
+                        // one message parse failure fails the test
+                        break;
+                    }
+                }
+                assert_eq!(recv_count, RECEIVE_CHECK_COUNT);
+            }
+        });
+
+        // have the client send a few hearbeats
+        thread::spawn({
+            move || {
+                let client = mavlink::connect("tcpout:127.0.0.1:14550")
+                    .expect("Couldn't create client");
+                loop {
+                    client.send_default(&heartbeat_message()).ok();
+                }
+            }
+        });
+
+        server_thread.join().unwrap();
+    }
+
+}

--- a/tests/udp_loopback_tests.rs
+++ b/tests/udp_loopback_tests.rs
@@ -20,6 +20,8 @@ mod test_udp_connections {
     /// Test whether we can send a message via UDP and receive it OK
     #[test]
     pub fn test_udp_loopback() {
+        const RECEIVE_CHECK_COUNT: i32 = 3;
+
         let server = mavlink::connect("udpin:0.0.0.0:14551")
             .expect("Couldn't create server");
 
@@ -37,15 +39,15 @@ mod test_udp_connections {
 
         //TODO use std::sync::WaitTimeoutResult to timeout ourselves if recv fails?
         let mut recv_count = 0;
-        for _i in 0..3 {
-            if let Ok(msg) = server.recv() {
-                println!("{:?}", msg);
+        for _i in 0..RECEIVE_CHECK_COUNT {
+            if let Ok(_msg) = server.recv() {
                 recv_count += 1;
             } else {
+                // one message parse failure fails the test
                 break;
             }
         }
-        assert_eq!(recv_count, 3);
+        assert_eq!(recv_count, RECEIVE_CHECK_COUNT);
 
     }
 

--- a/tests/udp_loopback_tests.rs
+++ b/tests/udp_loopback_tests.rs
@@ -1,0 +1,52 @@
+extern crate mavlink;
+
+#[cfg(test)]
+#[cfg(all(feature = "std", feature = "udp"))]
+mod test_udp_connections {
+    use std::thread;
+
+    /// Create a heartbeat message
+    pub fn heartbeat_message() -> mavlink::common::MavMessage {
+        mavlink::common::MavMessage::HEARTBEAT(mavlink::common::HEARTBEAT_DATA {
+            custom_mode: 0,
+            mavtype: mavlink::common::MavType::MAV_TYPE_QUADROTOR,
+            autopilot: mavlink::common::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+            base_mode: mavlink::common::MavModeFlag::empty(),
+            system_status: mavlink::common::MavState::MAV_STATE_STANDBY,
+            mavlink_version: 0x3,
+        })
+    }
+
+    /// Test whether we can send a message via UDP and receive it OK
+    #[test]
+    pub fn test_udp_loopback() {
+        let server = mavlink::connect("udpin:0.0.0.0:14551")
+            .expect("Couldn't create server");
+
+
+        // have the client send one heartbeat per second
+        thread::spawn({
+            move || {
+                let client = mavlink::connect("udpout:127.0.0.1:14551")
+                    .expect("Couldn't create client");
+                loop {
+                    client.send_default(&heartbeat_message()).ok();
+                }
+            }
+        });
+
+        //TODO use std::sync::WaitTimeoutResult to timeout ourselves if recv fails?
+        let mut recv_count = 0;
+        for _i in 0..3 {
+            if let Ok(msg) = server.recv() {
+                println!("{:?}", msg);
+                recv_count += 1;
+            } else {
+                break;
+            }
+        }
+        assert_eq!(recv_count, 3);
+
+    }
+
+}


### PR DESCRIPTION

- Builds under rust stable 
- Supports mavlink2
- Adds support for truncated msg payloads (per mavlink spec)
- Fixes tcpout
- Adds tcpin (server)
- Add feature flags for udp and tcp
- Adds loopback tests for udp, tcp